### PR TITLE
Add support for ropevim_goto_def_newwin variable

### DIFF
--- a/ropevim.py
+++ b/ropevim.py
@@ -193,8 +193,8 @@ class VimUtils(ropemode.environment.Environment):
             vim.command('tab drop %s' % filename)
             return
 
-        if new:
-            vim.command('new')
+        if new in ('new', 'vnew'):
+            vim.command(new)
         vim.command('e %s' % filename)
 
     def find_file(self, filename, readonly=False, other=False, force=False):


### PR DESCRIPTION
As per doc/readme.txt there should be an option to define where should
be a new found definition opened. Seems like the implementation is
missing in current tree. In ropemode the variable is passed via 'other'
parameters. This patch uses 'other' in case it fits into words defined
in readme.txt ('new' or 'vnew') otherwise it opens in current buffer.

Resolves: https://github.com/python-rope/ropevim/issues/11