### PR TITLE
Fixed ugly printing messages.

### DIFF
--- a/ropevim.py
+++ b/ropevim.py
@@ -386,7 +386,7 @@ class VimProgress(object):
 def echo(message):
     if isinstance(message, unicode):
         message = message.encode(vim.eval('&encoding'))
-    print message
+    vim.command('echo "{}"'.format(message))
 
 def call(command):
     return vim.eval(command)


### PR DESCRIPTION
Displaying messages with python's print method makes the messages unaligned. I've changed the message to be printed with vim command echo. 