### PR TITLE
Updating link to Rope project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Ropevim is a vim mode that uses rope_ library to provide features like
 python refactorings and code-assists.  You should install rope_
 library before using ropevim.
 
-.. _rope: http://rope.sf.net/
+.. _rope: https://github.com/python-rope/rope
 
 
 New Features


### PR DESCRIPTION
As of this commit the sourceforge page just links to back to the Github project.