### PR TITLE
Optionally force ropevim to use python3.

### DIFF
--- a/doc/ropevim.txt
+++ b/doc/ropevim.txt
@@ -229,6 +229,7 @@ restructuring can be: >
                                   python3 interpreter, if it is available,
                                   even for python2 scripts. This should help
                                   reducing the use of python2-only idioms.
+                                  It can be set local to a buffer or globally.
                                   The default value is `0`.
 
 *'ropevim_codeassist_maxfixes'*     The maximum number of syntax errors

--- a/doc/ropevim.txt
+++ b/doc/ropevim.txt
@@ -225,6 +225,12 @@ restructuring can be: >
 8. Variables ~
                                                                  *RopeVariables*
 
+*'ropevim_prefer_py3'*            If non-zero, ropevim will run under the
+                                  python3 interpreter, if it is available,
+                                  even for python2 scripts. This should help
+                                  reducing the use of python2-only idioms.
+                                  The default value is `0`.
+
 *'ropevim_codeassist_maxfixes'*     The maximum number of syntax errors
                                   to fix for code assists.
                                   The default value is `1`.

--- a/ftplugin/python_ropevim.vim
+++ b/ftplugin/python_ropevim.vim
@@ -1,9 +1,17 @@
-if !has("python")
-    finish
+if has("python3") && get(g:, "ropevim_prefer_py3", 0)
+  " Force the use of python3 also in python2 scripts.
+  " This needs to be enabled explicitly: 
+  " doing so should help with python3 compatiblity,
+  " but could require dropping python2.6- support.
+  command! -buffer -nargs=+ PythonCmd python3 <args>
+elseif has("python2") || has("python")
+  command! -buffer -nargs=+ PythonCmd python <args>
+else
+  finish
 endif
 
 function! LoadRope()
-python << EOF
+  PythonCmd << EOF
 import ropevim
 from rope_omni import RopeOmniCompleter
 EOF
@@ -17,9 +25,9 @@ call LoadRope()
 function! RopeCompleteFunc(findstart, base)
     " A completefunc for python code using rope
     if (a:findstart)
-        py ropecompleter = RopeOmniCompleter(vim.eval("a:base"))
-        py vim.command("return %s" % ropecompleter.start)
+        PythonCmd ropecompleter = RopeOmniCompleter(vim.eval("a:base"))
+        PythonCmd vim.command("return %s" % ropecompleter.start)
     else
-        py vim.command("return %s" % ropecompleter.complete(vim.eval("a:base")))
+        PythonCmd vim.command("return %s" % ropecompleter.complete(vim.eval("a:base")))
     endif
 endfunction

--- a/ftplugin/python_ropevim.vim
+++ b/ftplugin/python_ropevim.vim
@@ -1,4 +1,4 @@
-if has("python3") && get(g:, "ropevim_prefer_py3", 0)
+if has("python3") && (get(g:, "ropevim_prefer_py3", 0) || get(b:, "ropevim_prefer_py3", 0))
   " Force the use of python3 also in python2 scripts.
   " This needs to be enabled explicitly: 
   " doing so should help with python3 compatiblity,

--- a/rope_omni.py
+++ b/rope_omni.py
@@ -20,7 +20,7 @@ class RopeOmniCompleter(object):
             elif isinstance(obj, dict):
                 return u'{' + u','.join([
                     u"%s:%s" % (conv(key), conv(value))
-                    for key, value in obj.iteritems()]) + u'}'
+                    for key, value in obj.items()]) + u'}'
             else:
                 return u'"%s"' % str(obj).replace(u'"', u'\\"')
         return conv(inp)

--- a/ropevim.py
+++ b/ropevim.py
@@ -394,7 +394,7 @@ class VimUtils(ropemode.environment.Environment):
         ret = u'{%s}' % \
               u','.join(u'"%s":"%s"' %
                         (key, value.replace('"', '\\"'))
-                        for (key, value) in ci.iteritems())
+                        for (key, value) in ci.items())
         return ret
 
 

--- a/ropevim.py
+++ b/ropevim.py
@@ -107,7 +107,10 @@ class VimUtils(ropemode.environment.Environment):
         return line.encode(self._get_encoding())
 
     def _decode_line(self, line):
-        return line.decode(self._get_encoding())
+        if hasattr(line, 'decode'):
+            return line.decode(self._get_encoding())
+        else:
+            return line
 
     def _position_to_offset(self, lineno, colno):
         result = min(colno, len(self.buffer[lineno - 1]) + 1)

--- a/ropevim.py
+++ b/ropevim.py
@@ -425,8 +425,6 @@ class VimProgress(object):
 
 
 def echo(message):
-    if isinstance(message, unicode):
-        message = message.encode(vim.eval('&encoding'))
     print(message)
 
 


### PR DESCRIPTION
Hello, thank you very much for this plugin, I used it extensively.

The only problem it ever gave me is that, running under Python2, it does not work when using Python3-only features.
To overcome this limit I introduced a way to optionally force ropevim to use Python3 syntax via a new variable.
Personally, I set the variable globally, so that even my Python2 scripts get better forward compatibility, but it can be set local to a buffer at need or automatically via autocommand if the intended version of Python can be guessed..

In the few months I used this option I did not observe problems. When renaming variables, the refactoring is applied to f-strings too.

I submit this pull request so that my approach can be examined and tested by a wider audience, possibly integrated upstream.