### PR TITLE
Closes #83. Change :map -> :noremap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -379,7 +379,7 @@ Shortcuts
 Some commands are used very frequently; specially the commands in        
 code-assist group.  You can define your own shortcuts like this::        
                                                                          
-  :map <C-c>g :call RopeGotoDefinition()                                
+  :noremap <C-c>g :call RopeGotoDefinition()                                
                                                                          
 Ropevim itself comes with a few shortcuts.  These shortcuts will be      
 used only when ``ropevim_enable_shortcuts`` is set.                      

--- a/doc/ropevim.txt
+++ b/doc/ropevim.txt
@@ -328,7 +328,7 @@ C-c r a c         |:RopeShowCalltip|
 Some commands are used very frequently; specially the commands in
 code-assist group.  You can define your own shortcuts like this: >
 
-  :map <C-c>g :call RopeGotoDefinition()
+  :noremap <C-c>g :call RopeGotoDefinition()
 
 <
 

--- a/ropevim.py
+++ b/ropevim.py
@@ -328,7 +328,7 @@ class VimUtils(ropemode.environment.Environment):
                     (_vim_name(name), _vim_name(name)))
         if key is not None:
             key = prekey + key.replace(' ', '')
-            vim.command('map %s :call %s()<cr>' % (key, _vim_name(name)))
+            vim.command('noremap %s :call %s()<cr>' % (key, _vim_name(name)))
 
     def _add_function(self, name, callback, prefix=False):
         globals()[name] = callback
@@ -520,7 +520,7 @@ def _init_variables():
 def _enable_shortcuts(env):
     if env.get('enable_shortcuts'):
         for command, shortcut in shortcuts.items():
-            vim.command('map %s :call %s()<cr>' %
+            vim.command('noremap %s :call %s()<cr>' %
                         (shortcut, _vim_name(command)))
         for command, shortcut in insert_shortcuts.items():
             command_name = _vim_name(command) + 'InsertMode'


### PR DESCRIPTION
This pull request resolves an issue with vim maps defined by `ropevim.py` having remapping enabled.

As mentioned in #83, if the user defines a mapping such as
```
noremap : <nop>
```
in their `.vimrc`, then all of the mappings defined by ropevim will fail. This issue is resolved by changing the ropevim map declarations from `:map ...` to `:noremap ...`.