### PR TITLE
Fix off by one selection of extract variable/method

### DIFF
--- a/ropevim.py
+++ b/ropevim.py
@@ -125,7 +125,7 @@ class VimUtils(ropemode.environment.Environment):
         end_mark = self.buffer.mark('>')
         if beg_mark and end_mark:
             start = self._position_to_offset(*beg_mark)
-            end = self._position_to_offset(*end_mark)
+            end = self._position_to_offset(*end_mark) + 1
             return start, end
         else:
             return 0, 0


### PR DESCRIPTION
This is an almost identical bug to a [very similar issue in python-mode](https://github.com/python-mode/python-mode/pull/957). The way ropevim treats cursor selection for refactoring is not what vim users are used to, which seems to have surprised some users as well: https://github.com/python-rope/ropevim/issues/64

Fix #64 